### PR TITLE
Improve build configuration for NativeAOT

### DIFF
--- a/fable-raytracer.fsproj
+++ b/fable-raytracer.fsproj
@@ -7,6 +7,12 @@
     <!-- <NoWarn>$(NoWarn);45;55;62;75;1204</NoWarn> -->
     <!-- <OtherFlags>$(OtherFlags) - -crossoptimize- - -inlinethreshold:0</OtherFlags> -->
     <!-- <OtherFlags>$(OtherFlags) - -tailcalls+</OtherFlags> -->
+    <RestoreAdditionalProjectSources Condition="$(RunNativeAot) == True">
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json;
+      $(RestoreAdditionalProjectSources)
+    </RestoreAdditionalProjectSources>
+    <IlcDisableReflection>true</IlcDisableReflection>
+    <IlcOptimizationPreference>Size</IlcOptimizationPreference>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-*" /> -->
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-*" Condition="$(RunNativeAot) == True" />
     <PackageReference Include="Fable.Core" Version="3.6.1" />
   </ItemGroup>
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build-cli": "dotnet run -c Release --project ../Fable/src/Fable.Cli -- fable-raytracer.fsproj --outDir out",
     "build-rust-lib": "dotnet run -c Release --project ../Fable/src/Fable.Cli -- ../Fable/src/fable-library-rust/src --outDir build/fable-library-rust/src  --fableLib . --exclude Fable.Core --define FABLE_LIBRARY --lang Rust --noCache",
     "build-rust": "dotnet run -c Release --project ../Fable/src/Fable.Cli -- fable-raytracer.fsproj --outDir .  --fableLib . --lang Rust --noCache",
-    "build-native": "dotnet publish -c Release -r linux-x64 --self-contained",
+    "build-native": "dotnet publish -c Release -r linux-x64 --self-contained /p:RunNativeAot=True && strip bin/Release/net6.0/linux-x64/publish/fable-raytracer",
     "build-js": "dotnet fable fable-raytracer.fsproj --outDir out",
 
     "build-wasm-web": "wasm-pack build --target web",


### PR DESCRIPTION
This produce EXE of 2.5Mb after strip executable from debug symbols. Without strip it's 9Mb size, still notably smaller then with reflection. Execution speed about same as .NET, but on Linux perception that startup time is faster even if I add `--no-build`.

Slap `<IlcOptimizationPreference>Size</IlcOptimizationPreference>` and you get NativeAOT version run faster by ~10%. It will shave 150ms from 1312ms to 1168ms (-10%) (I do have very old laptop)


This is just to make sure that NativeAOT is compiling in your repo without much friction. 