### PR TITLE
Additional npm run target with `target-cpu=native` for Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ https://ncave.github.io/fable-raytracer/
   - `npm run test-web` (F# to Rust to WebAssembly, in Browser, localhost:8080)
   - `npm run test-wasm` (F# to Rust to WebAssembly, running in Node.js)
   - `npm run test-rust` (F# to Rust, running as native binary)
+    - `npm run test-rust-target-cpu` (as above, but allow Rust to target your CPU and use newer instructions)
   - `npm run test-dotnet` (F# running on .NET as managed code)
   - `npm run test-native` (F# running on .NET as native binary)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test-web": "npm run build-wasm-web && npx http-server",
     "test-wasm": "npm run build-wasm-node && node src/test_wasm.js",
     "test-rust": "npm run build-rust && cargo run --release",
+    "test-rust-target-cpu": "npm run build-rust && RUSTFLAGS=\"-C target-cpu=native\" cargo run --release",
     "test-dotnet": "dotnet run -c Release",
     "test-native": "npm run build-native && bin/Release/net6.0/linux-x64/native/fable-raytracer",
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test-web": "npm run build-wasm-web && npx http-server",
     "test-wasm": "npm run build-wasm-node && node src/test_wasm.js",
     "test-rust": "npm run build-rust && cargo run --release",
-    "test-rust-target-cpu": "npm run build-rust && RUSTFLAGS=\"-C target-cpu=native\" cargo run --release",
+    "test-rust-target-cpu": "npm run build-rust && cargo run --config build.rustflags='\"-C target-cpu=native\"' --release",
     "test-dotnet": "dotnet run -c Release",
     "test-native": "npm run build-native && bin/Release/net6.0/linux-x64/native/fable-raytracer",
 


### PR DESCRIPTION
This small constribution adds a new run script: `npm run test-rust-target-cpu`. It does the same as `npm run test-rust`, but allows Rust to target the current host machine's CPU. I've updated README.md too. This relates to #6.

It was a bit of a fiddle to get it working on Windows too, since the usual approach of setting an environment variable for RUSTFLAGS isn't quite as easy. Luckily Cargo has a `--config` argument we can use to achieve the same objective.

