### PR TITLE
Fable Python support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ https://ncave.github.io/fable-raytracer/
     - `npm run test-rust-target-cpu` (as above, but allow Rust to target your CPU and use newer instructions)
   - `npm run test-dotnet` (F# running on .NET as managed code)
   - `npm run test-native` (F# running on .NET as native binary)
+  - `npm run test-python` (F# to Python, running as Python)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build-native": "dotnet publish -c Release -r linux-x64 /p:PublishAot=True",
     "build-wasm-web": "npm run build-rust && wasm-pack build --target web",
     "build-wasm-node": "npm run build-rust && wasm-pack build --target nodejs",
+    "build-python": "dotnet fable fable-raytracer.fsproj --lang python --outDir src",
 
     "test-js": "npm run build-js && node out/src/main.js",
     "test-web": "npm run build-wasm-web && npx http-server",
@@ -19,6 +20,7 @@
     "test-rust-target-cpu": "npm run build-rust && cargo run --config build.rustflags='\"-C target-cpu=native\"' --release",
     "test-dotnet": "dotnet run -c Release",
     "test-native": "npm run build-native && bin/Release/net7.0/linux-x64/native/fable-raytracer",
+    "test-python": "npm run build-python && python src/main.py",
 
     "trace": "dotnet trace collect --format speedscope -- dotnet bin/Release/net7.0/fable-raytracer.dll",
     "preperf": "RUSTFLAGS='-C force-frame-pointers=yes' cargo build --release",

--- a/src/Platform.fs
+++ b/src/Platform.fs
@@ -28,8 +28,24 @@ let measureTime (f: unit -> 'T): 'T * float =
 
 #endif
 
+#if FABLE_COMPILER_PYTHON
+
+open Fable.Core
+open System.Diagnostics
+
+let measureTime (f: unit -> 'T): 'T * float =
+    let freq = double System.Diagnostics.Stopwatch.Frequency
+    let t0 = Stopwatch.GetTimestamp()
+    let res = f ()
+    let t1 = Stopwatch.GetTimestamp()
+    let elapsed = double (t1 - t0) / freq
+    res, elapsed * 1000.0
+
+#endif
+
+
 // #if FABLE_COMPILER_JAVASCRIPT
-#if FABLE_COMPILER && !FABLE_COMPILER_RUST
+#if FABLE_COMPILER && !FABLE_COMPILER_RUST && !FABLE_COMPILER_PYTHON
 
 open Fable.Core.JsInterop
 


### PR DESCRIPTION
- Yes, it's slow. But added for completeness (and to show that Python can be awfully slow for tight loops like this). 

PS: Needs a new Fable release to compile correctly, i.e 4.0.0-theta-019

```console
❯ python main.py
Raytracer running...
Ray tracing done:
 - rendered image size: (1024x1024)
 - elapsed: 94554.139777 ms
```